### PR TITLE
fix : 홈 화면에서 시청하기 버튼 클릭 시 로그인 페이지로 가도록 수정

### DIFF
--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="ASK" />
+    <option name="description" value="" />
+    <option name="applicationTheme" value="default" />
+    <option name="iconsTheme" value="default" />
+    <option name="button1Title" value="" />
+    <option name="button1Url" value="" />
+    <option name="button2Title" value="" />
+    <option name="button2Url" value="" />
+    <option name="customApplicationId" value="" />
+  </component>
+</project>

--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -2,16 +2,27 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { BrowseHeader } from "@/components/browse-header";
 import { HeroVideoPlayer } from "@/components/hero-video-player";
 import { videoApi, type Video } from "@/lib/api";
 import { Play, Info, Clock, Eye } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function BrowsePage() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
   const [videos, setVideos] = useState<Video[]>([]);
   const [loading, setLoading] = useState(true);
   const [featuredVideo, setFeaturedVideo] = useState<Video | null>(null);
   const [showVideoPlayer, setShowVideoPlayer] = useState(false);
+
+  // Auth guard - redirect to login if not authenticated
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.push("/login");
+    }
+  }, [isAuthenticated, authLoading, router]);
 
   useEffect(() => {
     loadVideos();
@@ -83,6 +94,10 @@ export default function BrowsePage() {
     { name: "컴투 대기", slug: "comedy", videos: getCategoryVideos("컴투 대기") },
     { name: "SF", slug: "sf", videos: getCategoryVideos("SF") },
   ];
+
+  if (authLoading || !isAuthenticated) {
+    return null;
+  }
 
   if (loading) {
     return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,7 +58,7 @@ export default function LandingPage() {
               다양한 디바이스에서 시청하세요. 언제든지 해지 가능합니다.
             </p>
             <div className="flex flex-wrap items-center gap-4">
-              <Link href="/browse">
+              <Link href="/login">
                 <Button size="lg" className="gap-2 bg-primary text-primary-foreground hover:bg-primary/90">
                   <Play className="h-5 w-5" fill="currentColor" />
                   지금 시청하기


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #21 

## 📝 작업 내용
 app/page.tsx — "지금 시청하기" 버튼이 이제 /browse 대신 /login으로 이동하도록 변경됨
app/browse/page.tsx — useAuth()를 사용한 인증 가드 추가
→ 인증되지 않은 사용자는 /login으로 리다이렉트
→ 인증 상태를 확인하는 동안에는 아무것도 렌더링하지 않음 (콘텐츠가 잠깐 보였다가 사라지는 현상 방지)

### ✨ 스크린샷

### 💬 리뷰 요구사항
