### PR TITLE
feature : 광고 영상 카테고리 선택 및 누끼 갤러리 UI 구현 (#32)

### DIFF
--- a/app/advertiser-studio/upload/page.tsx
+++ b/app/advertiser-studio/upload/page.tsx
@@ -6,15 +6,29 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { useToast } from '@/hooks/use-toast'
-import { Upload, Video, Loader2 } from 'lucide-react'
+import { Upload, Video, Loader2, Tag } from 'lucide-react'
 
 export default function AdvertiserStudioUploadPage() {
   const router = useRouter()
   const { toast } = useToast()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+const CATEGORIES = [
+  { value: 'FASHION',     label: '패션 (의류·신발·가방)' },
+  { value: 'FOOD',        label: '식품·음료' },
+  { value: 'ELECTRONICS', label: '전자기기' },
+  { value: 'BEAUTY',      label: '뷰티·화장품' },
+  { value: 'FURNITURE',   label: '가구·인테리어' },
+  { value: 'SPORTS',      label: '스포츠용품' },
+  { value: 'CAR',         label: '자동차' },
+  { value: 'PET',         label: '반려동물용품' },
+  { value: 'BOOK',        label: '도서·미디어' },
+  { value: 'TOY',         label: '완구·피규어' },
+] as const
+
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
+  const [objectCategory, setObjectCategory] = useState('')
   const [videoFile, setVideoFile] = useState<File | null>(null)
   const [uploading, setUploading] = useState(false)
   const [dragOver, setDragOver] = useState(false)
@@ -39,6 +53,10 @@ export default function AdvertiserStudioUploadPage() {
       toast({ title: '입력 오류', description: '제목을 입력해주세요', variant: 'destructive' })
       return
     }
+    if (!objectCategory) {
+      toast({ title: '입력 오류', description: '카테고리를 선택해주세요', variant: 'destructive' })
+      return
+    }
     if (!videoFile) {
       toast({ title: '파일 오류', description: '영상 파일을 선택해주세요', variant: 'destructive' })
       return
@@ -49,7 +67,7 @@ export default function AdvertiserStudioUploadPage() {
 
       const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
       const formData = new FormData()
-      formData.append('request', new Blob([JSON.stringify({ title, description })], { type: 'application/json' }))
+      formData.append('request', new Blob([JSON.stringify({ title, description, objectCategory })], { type: 'application/json' }))
       formData.append('videoFile', videoFile)
 
       const response = await fetch(`${baseUrl}/api/v1/advertiser/videos`, {
@@ -132,6 +150,27 @@ export default function AdvertiserStudioUploadPage() {
           <Textarea placeholder="영상 설명을 입력하세요 (선택)" rows={4} value={description}
             onChange={(e) => setDescription(e.target.value)} className="resize-none" />
         </div>
+        <div>
+          <label className="block text-sm font-medium mb-2">
+            <Tag className="inline h-3.5 w-3.5 mr-1 mb-0.5" />
+            누끼 추출 카테고리 <span className="text-red-500">*</span>
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            {CATEGORIES.map((cat) => (
+              <button
+                key={cat.value}
+                type="button"
+                onClick={() => setObjectCategory(cat.value)}
+                className={`px-3 py-2 rounded-lg border text-sm text-left transition-colors
+                  ${objectCategory === cat.value
+                    ? 'border-yellow-500 bg-yellow-500/10 text-yellow-600 font-medium'
+                    : 'border-border hover:border-yellow-500/50'}`}
+              >
+                {cat.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
 
       {/* 안내 */}
@@ -146,7 +185,7 @@ export default function AdvertiserStudioUploadPage() {
 
       <Button
         onClick={handleSubmit}
-        disabled={uploading || !videoFile || !title.trim()}
+        disabled={uploading || !videoFile || !title.trim() || !objectCategory}
         className="w-full bg-yellow-500 text-black hover:bg-yellow-400 font-semibold"
         size="lg"
       >

--- a/app/advertiser-studio/videos/[id]/nuki/page.tsx
+++ b/app/advertiser-studio/videos/[id]/nuki/page.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { apiClient } from '@/lib/api-client'
+import { useToast } from '@/hooks/use-toast'
+import { Button } from '@/components/ui/button'
+import { ArrowLeft, Download, ImageIcon, Loader2 } from 'lucide-react'
+
+interface NukiImagesResponse {
+  adVideoId: number
+  status: string
+  imageUrls: string[]
+}
+
+export default function NukiGalleryPage() {
+  const { id } = useParams<{ id: string }>()
+  const { toast } = useToast()
+  const [data, setData] = useState<NukiImagesResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState<string | null>(null)
+
+  useEffect(() => {
+    loadNukiImages()
+  }, [id])
+
+  const loadNukiImages = async () => {
+    try {
+      setLoading(true)
+      const result = await apiClient.get<NukiImagesResponse>(
+        `/api/v1/advertiser/videos/${id}/nuki`
+      )
+      setData(result)
+    } catch {
+      toast({ title: '불러오기 실패', description: '누끼 이미지를 불러오지 못했습니다', variant: 'destructive' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDownload = (url: string) => {
+    const filename = url.split('/').pop() ?? 'nuki.png'
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.click()
+  }
+
+  const handleDownloadAll = () => {
+    if (!data) return
+    data.imageUrls.forEach((url, i) => {
+      setTimeout(() => handleDownload(url), i * 150)
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link href="/advertiser-studio/videos">
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="h-4 w-4 mr-1" />뒤로
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold">누끼 이미지 갤러리</h1>
+            <p className="text-muted-foreground text-sm mt-0.5">영상 #{id} · AI가 추출한 누끼 이미지</p>
+          </div>
+        </div>
+        {data && data.imageUrls.length > 0 && (
+          <Button variant="outline" onClick={handleDownloadAll}>
+            <Download className="h-4 w-4 mr-2" />전체 다운로드
+          </Button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-yellow-500" />
+        </div>
+      ) : !data || data.imageUrls.length === 0 ? (
+        <div className="text-center py-16 border border-dashed border-border rounded-xl">
+          <ImageIcon className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+          <p className="font-semibold">누끼 이미지가 없습니다</p>
+          <p className="text-sm text-muted-foreground mt-1">AI 처리가 완료되지 않았거나 감지된 객체가 없습니다</p>
+        </div>
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground">총 {data.imageUrls.length}장</p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+            {data.imageUrls.map((url) => (
+              <div
+                key={url}
+                className="group relative aspect-square rounded-xl border border-border bg-muted overflow-hidden cursor-pointer hover:border-yellow-500 transition"
+                style={{ backgroundImage: 'url(/checkerboard.png)', backgroundSize: '20px' }}
+                onClick={() => setSelected(url)}
+              >
+                <img
+                  src={url}
+                  alt="누끼 이미지"
+                  className="w-full h-full object-contain"
+                />
+                <button
+                  className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition bg-black/60 rounded-lg p-1.5"
+                  onClick={(e) => { e.stopPropagation(); handleDownload(url) }}
+                >
+                  <Download className="h-3.5 w-3.5 text-white" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* 라이트박스 */}
+      {selected && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+          onClick={() => setSelected(null)}
+        >
+          <div
+            className="relative max-w-lg w-full rounded-2xl overflow-hidden bg-muted"
+            style={{ backgroundImage: 'url(/checkerboard.png)', backgroundSize: '20px' }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img src={selected} alt="누끼 이미지" className="w-full object-contain max-h-[70vh]" />
+            <div className="absolute top-3 right-3 flex gap-2">
+              <Button size="sm" variant="secondary" onClick={() => handleDownload(selected)}>
+                <Download className="h-3.5 w-3.5 mr-1" />다운로드
+              </Button>
+              <Button size="sm" variant="secondary" onClick={() => setSelected(null)}>닫기</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/advertiser-studio/videos/[id]/nuki/page.tsx
+++ b/app/advertiser-studio/videos/[id]/nuki/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { apiClient } from '@/lib/api-client'
 import { useToast } from '@/hooks/use-toast'
 import { Button } from '@/components/ui/button'
-import { ArrowLeft, Download, ImageIcon, Loader2 } from 'lucide-react'
+import { ArrowLeft, Download, ImageIcon, Loader2, XCircle, Clock } from 'lucide-react'
 
 interface NukiImagesResponse {
   adVideoId: number
@@ -24,6 +24,13 @@ export default function NukiGalleryPage() {
   useEffect(() => {
     loadNukiImages()
   }, [id])
+
+  // PROCESSING/PENDING 상태면 30초마다 자동 갱신
+  useEffect(() => {
+    if (!data || data.status === 'DONE' || data.status === 'FAILED') return
+    const timer = setInterval(loadNukiImages, 30_000)
+    return () => clearInterval(timer)
+  }, [data?.status])
 
   const loadNukiImages = async () => {
     try {
@@ -54,6 +61,80 @@ export default function NukiGalleryPage() {
     })
   }
 
+  const renderBody = () => {
+    if (loading) {
+      return (
+        <div className="flex justify-center py-20">
+          <Loader2 className="h-8 w-8 animate-spin text-yellow-500" />
+        </div>
+      )
+    }
+
+    if (!data) return null
+
+    if (data.status === 'PROCESSING' || data.status === 'PENDING') {
+      return (
+        <div className="text-center py-20 border border-dashed border-border rounded-xl space-y-4">
+          <Loader2 className="h-12 w-12 animate-spin text-yellow-500 mx-auto" />
+          <p className="font-semibold text-lg">AI가 누끼를 추출하는 중입니다</p>
+          <p className="text-sm text-muted-foreground">
+            영상 길이에 따라 30분~1시간 이상 소요될 수 있습니다.<br />
+            처리가 완료되면 자동으로 업데이트됩니다.
+          </p>
+          <p className="text-xs text-muted-foreground">30초마다 자동 새로고침</p>
+        </div>
+      )
+    }
+
+    if (data.status === 'FAILED') {
+      return (
+        <div className="text-center py-20 border border-dashed border-destructive/40 rounded-xl space-y-3 bg-destructive/5">
+          <XCircle className="h-12 w-12 text-destructive mx-auto" />
+          <p className="font-semibold text-lg">누끼 처리에 실패했습니다</p>
+          <p className="text-sm text-muted-foreground">영상을 다시 업로드하거나 관리자에게 문의해주세요.</p>
+        </div>
+      )
+    }
+
+    if (data.imageUrls.length === 0) {
+      return (
+        <div className="text-center py-16 border border-dashed border-border rounded-xl">
+          <ImageIcon className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+          <p className="font-semibold">감지된 객체가 없습니다</p>
+          <p className="text-sm text-muted-foreground mt-1">선택한 카테고리의 객체가 영상에서 발견되지 않았습니다</p>
+        </div>
+      )
+    }
+
+    return (
+      <>
+        <p className="text-sm text-muted-foreground">총 {data.imageUrls.length}장</p>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+          {data.imageUrls.map((url) => (
+            <div
+              key={url}
+              className="group relative aspect-square rounded-xl border border-border bg-muted overflow-hidden cursor-pointer hover:border-yellow-500 transition"
+              style={{ backgroundImage: 'repeating-conic-gradient(#e5e7eb 0% 25%, #ffffff 0% 50%)', backgroundSize: '20px 20px' }}
+              onClick={() => setSelected(url)}
+            >
+              <img
+                src={url}
+                alt="누끼 이미지"
+                className="w-full h-full object-contain"
+              />
+              <button
+                className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition bg-black/60 rounded-lg p-1.5"
+                onClick={(e) => { e.stopPropagation(); handleDownload(url) }}
+              >
+                <Download className="h-3.5 w-3.5 text-white" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </>
+    )
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -68,52 +149,15 @@ export default function NukiGalleryPage() {
             <p className="text-muted-foreground text-sm mt-0.5">영상 #{id} · AI가 추출한 누끼 이미지</p>
           </div>
         </div>
-        {data && data.imageUrls.length > 0 && (
+        {data?.status === 'DONE' && data.imageUrls.length > 0 && (
           <Button variant="outline" onClick={handleDownloadAll}>
             <Download className="h-4 w-4 mr-2" />전체 다운로드
           </Button>
         )}
       </div>
 
-      {loading ? (
-        <div className="flex justify-center py-20">
-          <Loader2 className="h-8 w-8 animate-spin text-yellow-500" />
-        </div>
-      ) : !data || data.imageUrls.length === 0 ? (
-        <div className="text-center py-16 border border-dashed border-border rounded-xl">
-          <ImageIcon className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-          <p className="font-semibold">누끼 이미지가 없습니다</p>
-          <p className="text-sm text-muted-foreground mt-1">AI 처리가 완료되지 않았거나 감지된 객체가 없습니다</p>
-        </div>
-      ) : (
-        <>
-          <p className="text-sm text-muted-foreground">총 {data.imageUrls.length}장</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-            {data.imageUrls.map((url) => (
-              <div
-                key={url}
-                className="group relative aspect-square rounded-xl border border-border bg-muted overflow-hidden cursor-pointer hover:border-yellow-500 transition"
-                style={{ backgroundImage: 'url(/checkerboard.png)', backgroundSize: '20px' }}
-                onClick={() => setSelected(url)}
-              >
-                <img
-                  src={url}
-                  alt="누끼 이미지"
-                  className="w-full h-full object-contain"
-                />
-                <button
-                  className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition bg-black/60 rounded-lg p-1.5"
-                  onClick={(e) => { e.stopPropagation(); handleDownload(url) }}
-                >
-                  <Download className="h-3.5 w-3.5 text-white" />
-                </button>
-              </div>
-            ))}
-          </div>
-        </>
-      )}
+      {renderBody()}
 
-      {/* 라이트박스 */}
       {selected && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
@@ -121,7 +165,7 @@ export default function NukiGalleryPage() {
         >
           <div
             className="relative max-w-lg w-full rounded-2xl overflow-hidden bg-muted"
-            style={{ backgroundImage: 'url(/checkerboard.png)', backgroundSize: '20px' }}
+            style={{ backgroundImage: 'repeating-conic-gradient(#e5e7eb 0% 25%, #ffffff 0% 50%)', backgroundSize: '20px 20px' }}
             onClick={(e) => e.stopPropagation()}
           >
             <img src={selected} alt="누끼 이미지" className="w-full object-contain max-h-[70vh]" />

--- a/app/advertiser-studio/videos/page.tsx
+++ b/app/advertiser-studio/videos/page.tsx
@@ -10,7 +10,7 @@ import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { Video, Upload, Trash2, CheckCircle, XCircle, Clock, Loader2, ImageIcon } from 'lucide-react'
+import { Video, Upload, Trash2, CheckCircle, XCircle, Clock, Loader2, ImageIcon, Eye } from 'lucide-react'
 
 interface AdVideo {
   id: number
@@ -128,11 +128,17 @@ export default function AdvertiserVideosPage() {
                   )}
                   {adVideo.status === 'DONE' && (
                     <div className="mt-2 p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
-                      <div className="flex items-center gap-2">
-                        <ImageIcon className="h-4 w-4 text-green-500" />
-                        <span className="text-sm font-medium text-green-500">누끼 이미지 처리 완료</span>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <ImageIcon className="h-4 w-4 text-green-500" />
+                          <span className="text-sm font-medium text-green-500">누끼 이미지 처리 완료</span>
+                        </div>
+                        <Link href={`/advertiser-studio/videos/${adVideo.id}/nuki`}>
+                          <Button size="sm" variant="outline" className="border-green-500/50 text-green-600 hover:bg-green-500/10">
+                            <Eye className="h-3.5 w-3.5 mr-1" />누끼 보기
+                          </Button>
+                        </Link>
                       </div>
-                      <p className="text-xs text-muted-foreground mt-1">{adVideo.nukiDirPath}</p>
                     </div>
                   )}
                 </div>

--- a/app/advertiser-studio/videos/page.tsx
+++ b/app/advertiser-studio/videos/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import { apiClient } from '@/lib/api-client'
 import { useToast } from '@/hooks/use-toast'
@@ -10,7 +10,7 @@ import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { Video, Upload, Trash2, CheckCircle, XCircle, Clock, Loader2, ImageIcon, Eye } from 'lucide-react'
+import { Video, Upload, Trash2, CheckCircle, XCircle, Clock, Loader2, ImageIcon, Eye, RefreshCw } from 'lucide-react'
 
 interface AdVideo {
   id: number
@@ -21,22 +21,36 @@ interface AdVideo {
   status: 'PENDING' | 'PROCESSING' | 'DONE' | 'FAILED'
   failReason?: string
   nukiDirPath?: string
+  objectCategory?: string
   createdAt: string
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  FASHION: '패션',
+  FOOD: '식품/음료',
+  ELECTRONICS: '전자기기',
+  BEAUTY: '뷰티',
+  FURNITURE: '가구',
+  SPORTS: '스포츠',
+  CAR: '자동차',
+  PET: '반려동물',
+  BOOK: '도서',
+  TOY: '장난감',
 }
 
 export default function AdvertiserVideosPage() {
   const { toast } = useToast()
   const [adVideos, setAdVideos] = useState<AdVideo[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
   const [page, setPage] = useState(0)
   const [totalPages, setTotalPages] = useState(0)
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
 
-  useEffect(() => { loadAdVideos() }, [page])
-
-  const loadAdVideos = async () => {
+  const loadAdVideos = useCallback(async (silent = false) => {
     try {
-      setLoading(true)
+      if (!silent) setLoading(true)
+      else setRefreshing(true)
       const data = await apiClient.get<any>(`/api/v1/advertiser/videos?page=${page}&size=20`)
       setAdVideos(data.content || [])
       setTotalPages(data.totalPages || 0)
@@ -44,8 +58,19 @@ export default function AdvertiserVideosPage() {
       toast({ title: '불러오기 실패', description: '광고 영상 목록을 불러오지 못했습니다', variant: 'destructive' })
     } finally {
       setLoading(false)
+      setRefreshing(false)
     }
-  }
+  }, [page])
+
+  useEffect(() => { loadAdVideos() }, [loadAdVideos])
+
+  // PENDING/PROCESSING 항목이 있으면 30초마다 자동 갱신
+  useEffect(() => {
+    const hasPending = adVideos.some(v => v.status === 'PENDING' || v.status === 'PROCESSING')
+    if (!hasPending) return
+    const timer = setInterval(() => loadAdVideos(true), 30_000)
+    return () => clearInterval(timer)
+  }, [adVideos, loadAdVideos])
 
   const handleDelete = async () => {
     if (!deleteTargetId) return
@@ -62,29 +87,54 @@ export default function AdvertiserVideosPage() {
 
   const getStatusBadge = (status: AdVideo['status']) => {
     switch (status) {
-      case 'PENDING':    return <Badge variant="secondary"><Clock className="h-3 w-3 mr-1" />처리 대기</Badge>
-      case 'PROCESSING': return <Badge variant="default"><Loader2 className="h-3 w-3 mr-1 animate-spin" />처리 중</Badge>
-      case 'DONE':       return <Badge className="bg-green-500"><CheckCircle className="h-3 w-3 mr-1" />완료</Badge>
-      case 'FAILED':     return <Badge variant="destructive"><XCircle className="h-3 w-3 mr-1" />실패</Badge>
+      case 'PENDING':
+        return <Badge variant="secondary" className="gap-1"><Clock className="h-3 w-3" />처리 대기</Badge>
+      case 'PROCESSING':
+        return <Badge className="gap-1 bg-blue-500 hover:bg-blue-500"><Loader2 className="h-3 w-3 animate-spin" />AI 분석 중</Badge>
+      case 'DONE':
+        return <Badge className="gap-1 bg-green-500 hover:bg-green-500"><CheckCircle className="h-3 w-3" />완료</Badge>
+      case 'FAILED':
+        return <Badge variant="destructive" className="gap-1"><XCircle className="h-3 w-3" />실패</Badge>
     }
   }
 
-  const formatFileSize = (bytes: number) => `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+  const formatFileSize = (bytes: number) => `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  const formatDate = (iso: string) => new Date(iso).toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' })
+
+  const processingCount = adVideos.filter(v => v.status === 'PENDING' || v.status === 'PROCESSING').length
 
   return (
     <div className="space-y-6">
+      {/* 헤더 */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">광고 영상 관리</h1>
           <p className="text-muted-foreground mt-1">업로드한 광고 영상과 누끼 처리 결과를 관리합니다</p>
         </div>
-        <Link href="/advertiser-studio/upload">
-          <Button className="bg-yellow-500 text-black hover:bg-yellow-400">
-            <Upload className="h-4 w-4 mr-2" />영상 업로드
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={() => loadAdVideos(true)} disabled={refreshing}>
+            <RefreshCw className={`h-4 w-4 mr-1 ${refreshing ? 'animate-spin' : ''}`} />새로고침
           </Button>
-        </Link>
+          <Link href="/advertiser-studio/upload">
+            <Button className="bg-yellow-500 text-black hover:bg-yellow-400">
+              <Upload className="h-4 w-4 mr-2" />영상 업로드
+            </Button>
+          </Link>
+        </div>
       </div>
 
+      {/* 처리 중 알림 배너 */}
+      {processingCount > 0 && (
+        <div className="flex items-center gap-3 px-4 py-3 rounded-xl bg-blue-500/10 border border-blue-500/20 text-sm text-blue-600">
+          <Loader2 className="h-4 w-4 animate-spin flex-shrink-0" />
+          <span>
+            <strong>{processingCount}개</strong>의 영상이 AI 누끼 처리 중입니다.
+            완료되면 자동으로 업데이트됩니다. (30분~1시간 소요)
+          </span>
+        </div>
+      )}
+
+      {/* 목록 */}
       {loading ? (
         <div className="flex justify-center py-12">
           <Loader2 className="h-8 w-8 animate-spin text-yellow-500" />
@@ -93,52 +143,95 @@ export default function AdvertiserVideosPage() {
         <div className="text-center py-16 border border-dashed border-border rounded-xl">
           <Video className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
           <h3 className="font-semibold text-lg mb-2">업로드한 광고 영상이 없습니다</h3>
+          <p className="text-sm text-muted-foreground mb-4">영상을 업로드하면 AI가 자동으로 누끼 이미지를 추출합니다</p>
           <Link href="/advertiser-studio/upload">
-            <Button className="mt-4 bg-yellow-500 text-black hover:bg-yellow-400">영상 업로드하기</Button>
+            <Button className="bg-yellow-500 text-black hover:bg-yellow-400">첫 영상 업로드하기</Button>
           </Link>
         </div>
       ) : (
-        <div className="space-y-4">
+        <div className="space-y-3">
           {adVideos.map((adVideo) => (
-            <div key={adVideo.id} className="bg-card border border-border rounded-xl p-5 hover:border-yellow-500/50 transition">
-              <div className="flex items-start gap-5">
-                <div className="flex h-24 w-40 flex-shrink-0 items-center justify-center rounded-lg bg-muted">
-                  <Video className="h-8 w-8 text-muted-foreground" />
+            <div
+              key={adVideo.id}
+              className="bg-card border border-border rounded-xl p-5 hover:border-yellow-500/40 transition"
+            >
+              <div className="flex items-start gap-4">
+                {/* 썸네일 영역 */}
+                <div className="flex h-20 w-32 flex-shrink-0 items-center justify-center rounded-lg bg-muted">
+                  <Video className="h-7 w-7 text-muted-foreground" />
                 </div>
-                <div className="flex-1 space-y-2">
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <h3 className="font-semibold text-lg">{adVideo.title}</h3>
+
+                {/* 콘텐츠 */}
+                <div className="flex-1 min-w-0 space-y-2">
+                  {/* 제목 + 삭제 */}
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <h3 className="font-semibold text-base truncate">{adVideo.title}</h3>
                       {adVideo.description && (
-                        <p className="text-sm text-muted-foreground line-clamp-1">{adVideo.description}</p>
+                        <p className="text-sm text-muted-foreground line-clamp-1 mt-0.5">{adVideo.description}</p>
                       )}
                     </div>
-                    <Button size="sm" variant="destructive" onClick={() => setDeleteTargetId(adVideo.id)}>
-                      <Trash2 className="h-4 w-4 mr-1" />삭제
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-muted-foreground hover:text-destructive flex-shrink-0"
+                      onClick={() => setDeleteTargetId(adVideo.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
                     </Button>
                   </div>
-                  <div>{getStatusBadge(adVideo.status)}</div>
-                  <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
-                    <span>{adVideo.originalFilename}</span>
-                    <span>{formatFileSize(adVideo.originalFileSize)}</span>
-                    <span>{new Date(adVideo.createdAt).toLocaleDateString('ko-KR')}</span>
+
+                  {/* 배지 행 */}
+                  <div className="flex flex-wrap items-center gap-2">
+                    {getStatusBadge(adVideo.status)}
+                    {adVideo.objectCategory && (
+                      <Badge variant="outline" className="text-xs">
+                        {CATEGORY_LABELS[adVideo.objectCategory] ?? adVideo.objectCategory}
+                      </Badge>
+                    )}
                   </div>
-                  {adVideo.status === 'FAILED' && adVideo.failReason && (
-                    <p className="text-sm text-destructive">실패 사유: {adVideo.failReason}</p>
+
+                  {/* 메타 정보 */}
+                  <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                    <span>{adVideo.originalFilename}</span>
+                    <span>·</span>
+                    <span>{formatFileSize(adVideo.originalFileSize)}</span>
+                    <span>·</span>
+                    <span>{formatDate(adVideo.createdAt)}</span>
+                  </div>
+
+                  {/* 상태별 추가 영역 */}
+                  {adVideo.status === 'PROCESSING' && (
+                    <div className="flex items-center gap-2 text-xs text-blue-600 bg-blue-500/10 rounded-lg px-3 py-2">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      AI가 객체를 탐지하고 누끼를 추출하고 있습니다…
+                    </div>
                   )}
+
+                  {adVideo.status === 'PENDING' && (
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/60 rounded-lg px-3 py-2">
+                      <Clock className="h-3 w-3" />
+                      잠시 후 처리가 시작됩니다
+                    </div>
+                  )}
+
+                  {adVideo.status === 'FAILED' && adVideo.failReason && (
+                    <div className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+                      실패 사유: {adVideo.failReason}
+                    </div>
+                  )}
+
                   {adVideo.status === 'DONE' && (
-                    <div className="mt-2 p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <ImageIcon className="h-4 w-4 text-green-500" />
-                          <span className="text-sm font-medium text-green-500">누끼 이미지 처리 완료</span>
-                        </div>
-                        <Link href={`/advertiser-studio/videos/${adVideo.id}/nuki`}>
-                          <Button size="sm" variant="outline" className="border-green-500/50 text-green-600 hover:bg-green-500/10">
-                            <Eye className="h-3.5 w-3.5 mr-1" />누끼 보기
-                          </Button>
-                        </Link>
+                    <div className="flex items-center justify-between bg-green-500/10 border border-green-500/20 rounded-lg px-3 py-2">
+                      <div className="flex items-center gap-2 text-xs text-green-600 font-medium">
+                        <ImageIcon className="h-3.5 w-3.5" />
+                        누끼 이미지 준비 완료
                       </div>
+                      <Link href={`/advertiser-studio/videos/${adVideo.id}/nuki`}>
+                        <Button size="sm" variant="outline" className="h-7 text-xs border-green-500/40 text-green-600 hover:bg-green-500/10">
+                          <Eye className="h-3 w-3 mr-1" />누끼 보기
+                        </Button>
+                      </Link>
                     </div>
                   )}
                 </div>
@@ -146,6 +239,7 @@ export default function AdvertiserVideosPage() {
             </div>
           ))}
 
+          {/* 페이지네이션 */}
           {totalPages > 1 && (
             <div className="flex justify-center gap-2 pt-4">
               <Button variant="outline" disabled={page === 0} onClick={() => setPage(p => p - 1)}>이전</Button>
@@ -156,15 +250,20 @@ export default function AdvertiserVideosPage() {
         </div>
       )}
 
+      {/* 삭제 확인 다이얼로그 */}
       <AlertDialog open={deleteTargetId !== null} onOpenChange={() => setDeleteTargetId(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>광고 영상을 삭제하시겠습니까?</AlertDialogTitle>
-            <AlertDialogDescription>영상 파일과 누끼 이미지가 모두 영구 삭제됩니다.</AlertDialogDescription>
+            <AlertDialogDescription>
+              영상 파일과 추출된 누끼 이미지가 모두 영구 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>취소</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">삭제</AlertDialogAction>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+              삭제
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #32

## 📝 작업 내용
> - 광고 영상 목록 페이지 전면 개편: 처리 중 배너, 수동 새로고침, PENDING/PROCESSING/DONE/FAILED 상태별 인라인 메시지
> - PENDING/PROCESSING 항목이 있을 때 30초마다 자동 새로고침 (`useCallback` + `setInterval`)
> - 카테고리 한글 라벨 매핑(`CATEGORY_LABELS`) 추가
> - 누끼 갤러리 페이지: 상태별 UI 분기 처리 및 30초 자동 갱신
> - `checkerboard.png` 404 오류 제거 — CSS `repeating-conic-gradient`로 대체

### ✨ 스크린샷

### 💬 리뷰 요구사항