### PR TITLE
feature : 합성 영상에 광고에 사용된 물품 정보 제공

### DIFF
--- a/app/advertiser-studio/upload/page.tsx
+++ b/app/advertiser-studio/upload/page.tsx
@@ -6,12 +6,13 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { useToast } from '@/hooks/use-toast'
-import { Upload, Video, Loader2, Tag } from 'lucide-react'
+import { Upload, Video, Loader2, Tag, Image } from 'lucide-react'
 
 export default function AdvertiserStudioUploadPage() {
   const router = useRouter()
   const { toast } = useToast()
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const imageInputRef = useRef<HTMLInputElement>(null)
 
 const CATEGORIES = [
   { value: 'FASHION',     label: '패션 (의류·신발·가방)' },
@@ -30,8 +31,10 @@ const CATEGORIES = [
   const [description, setDescription] = useState('')
   const [objectCategory, setObjectCategory] = useState('')
   const [videoFile, setVideoFile] = useState<File | null>(null)
+  const [adImageFile, setAdImageFile] = useState<File | null>(null)
   const [uploading, setUploading] = useState(false)
   const [dragOver, setDragOver] = useState(false)
+  const [imageDragOver, setImageDragOver] = useState(false)
 
   const handleFileSelect = (file: File) => {
     if (!file.type.startsWith('video/')) {
@@ -41,11 +44,26 @@ const CATEGORIES = [
     setVideoFile(file)
   }
 
+  const handleImageSelect = (file: File) => {
+    if (!file.type.startsWith('image/')) {
+      toast({ title: '파일 오류', description: '이미지 파일만 업로드할 수 있습니다', variant: 'destructive' })
+      return
+    }
+    setAdImageFile(file)
+  }
+
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault()
     setDragOver(false)
     const file = e.dataTransfer.files[0]
     if (file) handleFileSelect(file)
+  }
+
+  const handleImageDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setImageDragOver(false)
+    const file = e.dataTransfer.files[0]
+    if (file) handleImageSelect(file)
   }
 
   const handleSubmit = async () => {
@@ -61,6 +79,10 @@ const CATEGORIES = [
       toast({ title: '파일 오류', description: '영상 파일을 선택해주세요', variant: 'destructive' })
       return
     }
+    if (!adImageFile) {
+      toast({ title: '파일 오류', description: '광고 이미지를 선택해주세요', variant: 'destructive' })
+      return
+    }
 
     try {
       setUploading(true)
@@ -69,6 +91,7 @@ const CATEGORIES = [
       const formData = new FormData()
       formData.append('request', new Blob([JSON.stringify({ title, description, objectCategory })], { type: 'application/json' }))
       formData.append('videoFile', videoFile)
+      formData.append('adImageFile', adImageFile)
 
       const response = await fetch(`${baseUrl}/api/v1/advertiser/videos`, {
         method: 'POST',
@@ -102,7 +125,7 @@ const CATEGORIES = [
         <p className="text-muted-foreground mt-1">업로드 후 AI가 자동으로 영상 속 물체의 누끼를 추출합니다</p>
       </div>
 
-      {/* 파일 업로드 영역 */}
+      {/* 영상 파일 업로드 영역 */}
       <div
         className={`border-2 border-dashed rounded-xl p-10 text-center transition-colors cursor-pointer
           ${dragOver ? 'border-yellow-500 bg-yellow-500/5' : 'border-border hover:border-yellow-500/50'}
@@ -136,6 +159,47 @@ const CATEGORIES = [
             <p className="text-sm text-muted-foreground mt-1">MP4, MOV, AVI 등 영상 파일</p>
           </div>
         )}
+      </div>
+
+      {/* 광고 이미지 업로드 영역 */}
+      <div>
+        <label className="block text-sm font-medium mb-2">
+          광고 이미지 <span className="text-red-500">*</span>
+        </label>
+        <div
+          className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer
+            ${imageDragOver ? 'border-yellow-500 bg-yellow-500/5' : 'border-border hover:border-yellow-500/50'}
+            ${adImageFile ? 'border-green-500 bg-green-500/5' : ''}`}
+          onClick={() => imageInputRef.current?.click()}
+          onDragOver={(e) => { e.preventDefault(); setImageDragOver(true) }}
+          onDragLeave={() => setImageDragOver(false)}
+          onDrop={handleImageDrop}
+        >
+          <input
+            ref={imageInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => e.target.files?.[0] && handleImageSelect(e.target.files[0])}
+          />
+          {adImageFile ? (
+            <div>
+              <Image className="h-10 w-10 mx-auto mb-3 text-green-500" />
+              <p className="font-semibold text-green-600">{adImageFile.name}</p>
+              <p className="text-sm text-muted-foreground mt-1">{formatFileSize(adImageFile.size)}</p>
+              <Button variant="outline" size="sm" className="mt-3"
+                onClick={(e) => { e.stopPropagation(); setAdImageFile(null) }}>
+                파일 변경
+              </Button>
+            </div>
+          ) : (
+            <div>
+              <Image className="h-10 w-10 mx-auto mb-3 text-muted-foreground" />
+              <p className="font-semibold">광고에 사용할 이미지를 업로드하세요</p>
+              <p className="text-sm text-muted-foreground mt-1">JPG, PNG, WEBP 등 이미지 파일</p>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* 영상 정보 */}
@@ -185,7 +249,7 @@ const CATEGORIES = [
 
       <Button
         onClick={handleSubmit}
-        disabled={uploading || !videoFile || !title.trim() || !objectCategory}
+        disabled={uploading || !videoFile || !adImageFile || !title.trim() || !objectCategory}
         className="w-full bg-yellow-500 text-black hover:bg-yellow-400 font-semibold"
         size="lg"
       >

--- a/app/watch/[id]/page.tsx
+++ b/app/watch/[id]/page.tsx
@@ -58,7 +58,7 @@ export default function WatchPage({
   const [favoriteLoading, setFavoriteLoading] = useState(false);
   const [adInfo, setAdInfo] = useState<AdInfo | null>(null);
   const [showAdBanner, setShowAdBanner] = useState(true);
-  const [showAdModal, setShowAdModal] = useState(false);
+  const [showAdPanel, setShowAdPanel] = useState(false);
   const activeVideoIdRef = useRef<number | null>(null);
   const toggleRequestIdRef = useRef(0);
 
@@ -97,7 +97,7 @@ export default function WatchPage({
       setIsFavorited(false);
       setAdInfo(null);
       setShowAdBanner(true);
-      setShowAdModal(false);
+      setShowAdPanel(false);
       fetchVideo();
       favoritesApi.check(videoId)
           .then((res) => {
@@ -207,13 +207,13 @@ export default function WatchPage({
 
           {/* 유료 광고 포함 배너 */}
           {adInfo?.hasAd && showAdBanner && (
-            <div className="absolute top-4 right-4 z-40 flex items-center gap-2 bg-black/80 border border-white/10 backdrop-blur-sm text-white text-xs px-3 py-1.5 rounded-full animate-in fade-in slide-in-from-top-2 duration-500">
-              <Info className="h-3 w-3 text-gray-300 shrink-0" />
+            <div className="absolute top-4 right-4 z-40 flex items-center gap-2 bg-black/80 border border-white/10 backdrop-blur-sm text-white text-sm px-5 py-2.5 rounded-full animate-in fade-in slide-in-from-top-2 duration-500">
+              <Info className="h-4 w-4 text-gray-300 shrink-0" />
               <button
-                onClick={() => setShowAdModal(true)}
-                className="hover:underline underline-offset-2"
+                onClick={() => setShowAdPanel(true)}
+                className="hover:underline underline-offset-2 font-medium"
               >
-                유료 광고 포함
+                AI 광고 포함
               </button>
               <button
                 onClick={() => setShowAdBanner(false)}
@@ -225,57 +225,50 @@ export default function WatchPage({
           )}
         </div>
 
-        {/* 광고 정보 모달 */}
-        {showAdModal && adInfo && (
+        {/* 광고 정보 사이드 패널 */}
+        {adInfo?.hasAd && (
           <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-            onClick={() => setShowAdModal(false)}
+            className={`fixed top-0 right-0 h-full w-80 z-50 bg-zinc-900 border-l border-white/10 shadow-2xl flex flex-col transition-transform duration-300 ease-in-out ${
+              showAdPanel ? 'translate-x-0' : 'translate-x-full'
+            }`}
           >
-            <div
-              className="relative bg-zinc-900 rounded-2xl max-w-md w-full overflow-hidden"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {/* Red accent top border */}
-              <div className="h-1 w-full bg-red-600" />
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+              <h2 className="text-white font-bold text-base">AI 광고 포함</h2>
+              <button
+                onClick={() => setShowAdPanel(false)}
+                className="text-gray-500 hover:text-white transition"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
 
-              <div className="p-5">
-                {/* Header */}
-                <div className="flex items-center justify-between mb-4">
-                  <h2 className="text-white font-bold text-base">유료 광고 포함</h2>
-                  <button
-                    onClick={() => setShowAdModal(false)}
-                    className="text-gray-500 hover:text-white transition"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
-                </div>
+            {/* Ad notice */}
+            <p className="text-gray-400 text-xs px-5 pt-4 pb-2">
+              채널이(가) 태그된 제품에 대해 수수료를 받습니다.
+            </p>
 
-                {/* Horizontal layout — image left, info right */}
-                <div className="flex gap-4 items-center">
-                  {adInfo.nukiImageUrl && (
-                    <div
-                      className="rounded-xl overflow-hidden shrink-0 w-32 h-32 flex items-center justify-center"
-                      style={{ backgroundColor: '#18181b' }}
-                    >
-                      <img
-                        src={adInfo.nukiImageUrl}
-                        alt="광고 상품"
-                        className="w-full h-full object-contain"
-                      />
-                    </div>
-                  )}
-
-                  <div className="flex flex-col gap-2 min-w-0">
-                    {adInfo.advertiserName && (
-                      <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-red-600/20 text-red-400 border border-red-600/30 w-fit">
-                        광고주 · <span className="text-red-300">{adInfo.advertiserName}</span>
-                      </span>
-                    )}
-
-                    {adInfo.description && (
-                      <p className="text-gray-400 text-xs leading-relaxed line-clamp-3">{adInfo.description}</p>
-                    )}
+            {/* Ad card */}
+            <div className="px-4 py-3">
+              <div className="bg-zinc-800 rounded-xl overflow-hidden">
+                {adInfo.nukiImageUrl && (
+                  <div className="w-full aspect-video bg-zinc-700 flex items-center justify-center">
+                    <img
+                      src={toMediaUrl(adInfo.nukiImageUrl) ?? ''}
+                      alt="광고 상품"
+                      className="w-full h-full object-contain"
+                    />
                   </div>
+                )}
+                <div className="p-4 flex flex-col gap-2">
+                  {adInfo.advertiserName && (
+                    <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-red-600/20 text-red-400 border border-red-600/30 w-fit">
+                      광고주 · <span className="text-red-300">{adInfo.advertiserName}</span>
+                    </span>
+                  )}
+                  {adInfo.description && (
+                    <p className="text-white text-sm font-medium leading-snug">{adInfo.description}</p>
+                  )}
                 </div>
               </div>
             </div>

--- a/app/watch/[id]/page.tsx
+++ b/app/watch/[id]/page.tsx
@@ -5,8 +5,16 @@ import { useRouter, useSearchParams } from "next/navigation";
 import VideoPlayer from "@/components/VideoPlayer";
 import { videoApi, favoritesApi, toMediaUrl } from "@/lib/api";
 import { apiClient } from "@/lib/api-client";
-import { ArrowLeft, ThumbsUp, ThumbsDown, Heart, Volume2 } from "lucide-react";
+import { ArrowLeft, ThumbsUp, ThumbsDown, Heart, Volume2, X, Info } from "lucide-react";
 import { formatDuration } from "@/lib/format";
+
+interface AdInfo {
+  hasAd: boolean;
+  adVideoId: number | null;
+  advertiserName: string | null;
+  description: string | null;
+  nukiImageUrl: string | null;
+}
 
 // API 데이터 구조에 맞춰 string | null 허용
 interface Video {
@@ -48,6 +56,9 @@ export default function WatchPage({
   const [relatedVideos, setRelatedVideos] = useState<Video[]>([]);
   const [isFavorited, setIsFavorited] = useState(false);
   const [favoriteLoading, setFavoriteLoading] = useState(false);
+  const [adInfo, setAdInfo] = useState<AdInfo | null>(null);
+  const [showAdBanner, setShowAdBanner] = useState(true);
+  const [showAdModal, setShowAdModal] = useState(false);
   const activeVideoIdRef = useRef<number | null>(null);
   const toggleRequestIdRef = useRef(0);
 
@@ -84,6 +95,9 @@ export default function WatchPage({
 
     if (!isNaN(videoId)) {
       setIsFavorited(false);
+      setAdInfo(null);
+      setShowAdBanner(true);
+      setShowAdModal(false);
       fetchVideo();
       favoritesApi.check(videoId)
           .then((res) => {
@@ -91,6 +105,13 @@ export default function WatchPage({
         }).catch(() => {
           if (!cancelled) setIsFavorited(false);
         });
+      apiClient.get<AdInfo>(`/api/v1/video-compositions/${videoId}/ad-info`)
+          .then((res) => {
+            if (!cancelled && res.hasAd) {
+              setAdInfo(res);
+              setTimeout(() => { if (!cancelled) setShowAdBanner(false); }, 20000);
+            }
+          }).catch(() => {});
     }
     return () => {
       cancelled = true;
@@ -183,7 +204,83 @@ export default function WatchPage({
               poster={toMediaUrl(video.thumbnailUrl) || undefined}
               autoplay={autoplay}
           />
+
+          {/* 유료 광고 포함 배너 */}
+          {adInfo?.hasAd && showAdBanner && (
+            <div className="absolute top-4 right-4 z-40 flex items-center gap-2 bg-black/80 border border-white/10 backdrop-blur-sm text-white text-xs px-3 py-1.5 rounded-full animate-in fade-in slide-in-from-top-2 duration-500">
+              <Info className="h-3 w-3 text-gray-300 shrink-0" />
+              <button
+                onClick={() => setShowAdModal(true)}
+                className="hover:underline underline-offset-2"
+              >
+                유료 광고 포함
+              </button>
+              <button
+                onClick={() => setShowAdBanner(false)}
+                className="text-gray-500 hover:text-white transition ml-1"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          )}
         </div>
+
+        {/* 광고 정보 모달 */}
+        {showAdModal && adInfo && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+            onClick={() => setShowAdModal(false)}
+          >
+            <div
+              className="relative bg-zinc-900 rounded-2xl max-w-md w-full overflow-hidden"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* Red accent top border */}
+              <div className="h-1 w-full bg-red-600" />
+
+              <div className="p-5">
+                {/* Header */}
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-white font-bold text-base">유료 광고 포함</h2>
+                  <button
+                    onClick={() => setShowAdModal(false)}
+                    className="text-gray-500 hover:text-white transition"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+
+                {/* Horizontal layout — image left, info right */}
+                <div className="flex gap-4 items-center">
+                  {adInfo.nukiImageUrl && (
+                    <div
+                      className="rounded-xl overflow-hidden shrink-0 w-32 h-32 flex items-center justify-center"
+                      style={{ backgroundColor: '#18181b' }}
+                    >
+                      <img
+                        src={adInfo.nukiImageUrl}
+                        alt="광고 상품"
+                        className="w-full h-full object-contain"
+                      />
+                    </div>
+                  )}
+
+                  <div className="flex flex-col gap-2 min-w-0">
+                    {adInfo.advertiserName && (
+                      <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-red-600/20 text-red-400 border border-red-600/30 w-fit">
+                        광고주 · <span className="text-red-300">{adInfo.advertiserName}</span>
+                      </span>
+                    )}
+
+                    {adInfo.description && (
+                      <p className="text-gray-400 text-xs leading-relaxed line-clamp-3">{adInfo.description}</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
 
         <div className="fixed top-6 left-6 z-50">
           <button


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #50

## 📝 작업 내용
1. 합성 영상에 광고에 사용된 물품 정보를 사이드 슬라이드 방식으로 보여주도록 합니다.

2. 누끼 이미지를 사용하는 대신, 광고주가 광고 영상 업로드 동시에 광고 이미지도 함께 업로드 하여 그 이미지를 활용하도록 합니다.

### ✨ 스크린샷
<img width="1326" height="1042" alt="image" src="https://github.com/user-attachments/assets/14f73b0c-85b0-41c7-9a0e-3796c3fe4148" />

### 💬 리뷰 요구사항
